### PR TITLE
Migrate from `pykalman` to `pykalman-bardo`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ patsy==0.5.2
 Pillow==9.2.0
 pluggy==1.0.0
 py==1.11.0
-pykalman-bardo==0.9.6
+pykalman-bardo==0.9.7
 pyparsing==3.0.9
 pytest==7.1.3
 pytest-cov==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ patsy==0.5.2
 Pillow==9.2.0
 pluggy==1.0.0
 py==1.11.0
-pykalman==0.9.5
+pykalman-bardo==0.9.6
 pyparsing==3.0.9
 pytest==7.1.3
 pytest-cov==3.0.0


### PR DESCRIPTION
Consider migration from `pykalman` to `pykalman-bardo`, as [pykalman](https://github.com/pykalman/pykalman) project is no longer maintained. There were some issues that were fixed, see: https://github.com/pybardo/pykalman/blob/v0.9.7/CHANGELOG

I'm going to maintain [pykalman-bardo](https://github.com/pybardo/pykalman), react to issues, and fix bugs. For now the API is the same as in the initial package, but it might evolve in time.

I hope you will find it useful for your project!